### PR TITLE
Fixes for modules and some suggested adjustments

### DIFF
--- a/src/spack-downstream
+++ b/src/spack-downstream
@@ -74,8 +74,8 @@ copy_yaml () {
 
     # Modify modiles.yaml to add new lmod root
     if [ -f "$INSTALL_DIR/etc/spack/modules.yaml" ]; then
-	log "$INSTALL_DIR/bin/spack config add 'modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/modules/$VERSION'"
-	$INSTALL_DIR/bin/spack config add "modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/modules/$VERSION"
+	log "$INSTALL_DIR/bin/spack config add 'modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/$NCAR_HOST/modules/$VERSION'"
+	$INSTALL_DIR/bin/spack config add "modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/$NCAR_HOST/modules/$VERSION"
     fi
 }
 
@@ -145,7 +145,7 @@ echo "ncarenv version: $VERSION"
 
 # Set install path
 if [ -z "$PREFIX" ]; then
-    INSTALL_DIR="/glade/work/$USER/spack-downstreams/ncarenv-$VERSION"
+    INSTALL_DIR="/glade/work/$USER/spack-downstreams/$NCAR_HOST/$VERSION"
 else
     INSTALL_DIR=$PREFIX
 fi

--- a/src/spack-downstream
+++ b/src/spack-downstream
@@ -51,10 +51,15 @@ clone_repo () {
 # Copy system yaml information
 copy_yaml () {
      # Check to see if yaml files exist. If not clone them to the directory.
-    for file in compilers.yaml mirrors.yaml packages.yaml repos.yaml modules.yaml; do
+    for file in config.yaml compilers.yaml mirrors.yaml packages.yaml repos.yaml modules.yaml; do
         if [ ! -f "$INSTALL_DIR/etc/spack/$file" ]; then
-            log "cp /glade/u/apps/gust/default/config/$file $INSTALL_DIR/etc/spack"
-            cp /glade/u/apps/gust/default/config/$file $INSTALL_DIR/etc/spack
+            log "cp /glade/u/apps/$NCAR_HOST/default/config/$file $INSTALL_DIR/etc/spack"
+            cp /glade/u/apps/$NCAR_HOST/default/config/$file $INSTALL_DIR/etc/spack
+
+            if [ $file == modules.yaml ]; then
+                log "sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file"
+                sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file
+            fi
         fi
     done
 
@@ -63,8 +68,8 @@ copy_yaml () {
 
     # Check to see if upstreams has been created. If not create it and fill it with the following values.
     if [ ! -f "$INSTALL_DIR/etc/spack/upstreams.yaml" ]; then
-        log "$INSTALL_DIR/bin/spack config add 'upstreams:spack-instance-1:install_tree:/glade/u/apps/gust/$VERSION/spack/opt/spack/"
-        $INSTALL_DIR/bin/spack config add "upstreams:spack-instance-1:install_tree:/glade/u/apps/gust/$VERSION/spack/opt/spack/"
+        log "$INSTALL_DIR/bin/spack config add 'upstreams:spack-instance-1:install_tree:/glade/u/apps/$NCAR_HOST/$VERSION/spack/opt/spack/"
+        $INSTALL_DIR/bin/spack config add "upstreams:spack-instance-1:install_tree:/glade/u/apps/$NCAR_HOST/$VERSION/spack/opt/spack/"
     fi
 
     # Modify modiles.yaml to add new lmod root
@@ -140,7 +145,7 @@ echo "ncarenv version: $VERSION"
 
 # Set install path
 if [ -z "$PREFIX" ]; then
-    INSTALL_DIR="/glade/work/$USER/spack/ncarenv-$VERSION"
+    INSTALL_DIR="/glade/work/$USER/spack-downstreams/ncarenv-$VERSION"
 else
     INSTALL_DIR=$PREFIX
 fi


### PR DESCRIPTION
Here is a PR with a few suggested changes:

1. Add `config.yaml` to the copied settings. The most important setting in there is that it provides our modulefile templates, but I suspect the other settings will be generally useful or at least not interfere.
2. Switch the modules from using the `ncar_*` templates to the `user_*` templates, which mark the modules as User-generated when running **module avail**.
3. Replace `gust` with `$NCAR_HOST` so that it will work on Derecho and Casper too.
4. Change the prefix from `/glade/work/$USER/spack/...` to `/glade/work/$USER/spack-downstreams/...`. When I test it out, it created an `ncarenv-23.04` subdirectory in a Spack clone I had in my work. Not the end of the world, but I could see that happening to users and being annoying.