### PR TITLE
Bugfixes, some code changes, and csh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# Spack Upstreams Installation Utility
-Repository containing a spack installation utility for the NCAR Gust Test System.
+# Spack Downstream Installation Utility
+Repository containing a chained Spack installation setup utility for the NCAR HPC Systems.
 
 ## Basic usage:
-./spack-upstream.sh
+./spack-downstream
 
-By default the application will install a compatable version of spack with the upstream installation in the users work directory. Users can specify the installation directory with the `--prefix=<install-path>` flag. 
+By default the application will install a compatable version of Spack with the upstream installation in the users work directory. Users can specify the installation directory with the `--downstream-root=PATH` flag.
 
-Once the installation has completed, spack-upstreams will attempt to modify the user's `.bashrc` to automatically load spack into the user's enviornment in login.
+Once the installation has completed, spack-downstreams will attempt to modify the user's `.bashrc` to automatically load Spack into the user's enviornment in login.
 If the user chooses to skip this option, on login they will need to run:
-`<install-directory>/share/spack/setup-env.sh`
+`. $SPACK_ROOT/share/spack/setup-env.sh`
 
 ## Optional flags:
 ```
-       -v | --verbose                   : print out each installation step to the terminal
-            --prefix=<install-path>     : specify spack installation location. Default: /glade/work/mtrahan/spack_version  
-            --modify-rc=<True|False>.   : modify .bashrc to load Spack at startup
-            --version=<ncarenv-version> : specify ncarenv version. Default: default
-       -h | --help                      : print this message
+    -h, --help                      print this message
+    --downstream-root=PATH          specify installation location for downstreams.
+                                    (default: /glade/work/$USER/spack-downstreams)
+    --modify-rc=<True|False>        modify your startup script to automatically load Spack at startup
+    --upstream-version=VERSION      specify alternate ncarenv version. (default: $NCAR_ENV_VERSION)"
+    -v, --verbose                   print out each installation step to the terminal
 ```
 
-## Know bugs:
-- No tcsh or csh support yet.
-
+## Known bugs and limitations:
+- RC modification can only be done when the downstream is created.

--- a/bin/spack-downstream
+++ b/bin/spack-downstream
@@ -6,14 +6,19 @@
 
 # Simple printing function
 print_usage () {
-    echo "spack-downstreams: Script to set up a local spack instance and link it to the upstream system spack"
-    echo "usage:"
-    echo "       -v | --verbose                   : print out each installation step to the terminal"
-    echo "            --prefix=<install-path>     : specify spack installation location. Default: /glade/work/$USER/ncarenv-$VERSION"
-    echo "            --version=<ncarenv-version> : specify ncarenv version. Default: default"
-    echo "            --modify-rc=<True|False>    : modify your startup script to automatically load Spack at startup"
-    echo "       -h | --help                      : print this message"
-    
+cat << EOF
+Usage: spack-downstream [OPTIONS]
+Script to set up a personal downstream Spack instance and link it to the upstream system Spack.
+
+Optional arguments:
+    -h, --help                      print this message
+    --downstream-root=PATH          specify installation location for downstreams.
+                                    (default: /glade/work/$USER/spack-downstreams)
+    --modify-rc=OPTION              modify your startup script to automatically load Spack at startup
+                                    (valid options are "yes", "no", "bashrc", "tcshrc")
+    --upstream-version=VERSION      specify alternate ncarenv version. (default: $NCAR_ENV_VERSION)"
+    -v, --verbose                   print out each installation step to the terminal
+EOF
 }
 
 # Simple logging function
@@ -24,8 +29,14 @@ log () {
 }
 
 clone_repo () {
-    log "git config --global --add safe.directory /glade/u/apps/$NCAR_HOST/$VERSION/spack"
-    log "cd /glade/u/apps/gust/$VERSION/spack"
+    if [ -d "$INSTALL_DIR" ]; then
+         >&2 echo "Error: Installation directory at $INSTALL_DIR is not empty."
+         >&2 echo "       Please select an empty directory to install this application."
+         exit 1
+    fi
+
+    log "git config --global --add safe.directory /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack"
+    log "cd /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack"
     log "export GIT_COMMIT=$(git rev-parse HEAD)"
     log "cd - > /dev/null"
     log "git clone -c feature.manyFiles=true https://github.com/NCAR/csg-spack-fork $INSTALL_DIR"
@@ -33,16 +44,12 @@ clone_repo () {
     log "git checkout $GIT_COMMIT"
     log "cd - > /dev/null"
 
-    git config --global --add safe.directory /glade/u/apps/$NCAR_HOST/$VERSION/spack
-    cd /glade/u/apps/$NCAR_HOST/$VERSION/spack
+    git config --global --add safe.directory /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack
+    cd /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack
     export GIT_COMMIT=$(git rev-parse HEAD)
     cd - > /dev/null
-    git clone -c feature.manyFiles=true https://github.com/NCAR/csg-spack-fork $INSTALL_DIR
-    if [ ! $? -eq 0 ]; then
-         echo "spack-downstream error: Installation directory at: $INSTALL_DIR is not empty. Please select an empty directory to install this application."
-         exit 0
-    fi
-    
+    git clone -c feature.manyFiles=true https://github.com/NCAR/csg-spack-fork $INSTALL_DIR || exit 1
+
     cd $INSTALL_DIR
     git reset --hard $GIT_COMMIT
     cd - > /dev/null
@@ -50,144 +57,188 @@ clone_repo () {
 
 # Copy system yaml information
 copy_yaml () {
-     # Check to see if yaml files exist. If not clone them to the directory.
     for file in config.yaml compilers.yaml mirrors.yaml packages.yaml repos.yaml modules.yaml; do
-        if [ ! -f "$INSTALL_DIR/etc/spack/$file" ]; then
-            log "cp /glade/u/apps/$NCAR_HOST/default/config/$file $INSTALL_DIR/etc/spack"
-            cp /glade/u/apps/$NCAR_HOST/default/config/$file $INSTALL_DIR/etc/spack
+        log "cp /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/config/$file $INSTALL_DIR/etc/spack"
+        cp /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/config/$file $INSTALL_DIR/etc/spack
 
-            if [ $file == modules.yaml ]; then
-                log "sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file"
-                sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file
-            fi
+        if [ $file == modules.yaml ]; then
+            log "sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file"
+            sed -i '/ncar_.*\.lua/ s/ncar/user/' $INSTALL_DIR/etc/spack/$file
         fi
     done
 
     # Disable Local Configuration
     export SPACK_DISABLE_LOCAL_CONFIG=true
 
-    # Check to see if upstreams has been created. If not create it and fill it with the following values.
-    if [ ! -f "$INSTALL_DIR/etc/spack/upstreams.yaml" ]; then
-        log "$INSTALL_DIR/bin/spack config add 'upstreams:spack-instance-1:install_tree:/glade/u/apps/$NCAR_HOST/$VERSION/spack/opt/spack/"
-        $INSTALL_DIR/bin/spack config add "upstreams:spack-instance-1:install_tree:/glade/u/apps/$NCAR_HOST/$VERSION/spack/opt/spack/"
-    fi
+    log "$INSTALL_DIR/bin/spack config add 'upstreams:ncarenv-$UPSTREAM_VERSION:install_tree:/glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack/opt/spack"
+    $INSTALL_DIR/bin/spack config add "upstreams:ncarenv-$UPSTREAM_VERSION:install_tree:/glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION/spack/opt/spack"
 
-    # Modify modiles.yaml to add new lmod root
-    if [ -f "$INSTALL_DIR/etc/spack/modules.yaml" ]; then
-	log "$INSTALL_DIR/bin/spack config add 'modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/$NCAR_HOST/modules/$VERSION'"
-	$INSTALL_DIR/bin/spack config add "modules:default:roots:lmod:/glade/work/$USER/spack-downstreams/$NCAR_HOST/modules/$VERSION"
-    fi
+	log "$INSTALL_DIR/bin/spack config add 'modules:default:roots:lmod:${DOWNSTREAM_ROOT:-/glade/work/$USER/spack-downstreams}/$NCAR_HOST/modules/$UPSTREAM_VERSION'"
+	$INSTALL_DIR/bin/spack config add "modules:default:roots:lmod:${DOWNSTREAM_ROOT:-/glade/work/$USER/spack-downstreams}/$NCAR_HOST/modules/$UPSTREAM_VERSION"
 }
 
 # Check for existing RC modifications from previous spack-downstream installs
 check_rc () {
-    # Check if bashrc exists. Create if not present.
-    if [ ! -f "~/.bashrc" ]; then
-        touch ~/.bashrc 
-    fi
-
     # Check for existing spack downstream install if it exists prompt user to replace or skip.
-    log export CHECK_INSTALL=$(egrep -c "SPACK DOWNSTREAMS INITIALIZE" ~/.bashrc)
-    export CHECK_INSTALL=$(egrep -c "SPACK DOWNSTREAMS INITIALIZE" ~/.bashrc) 
-    if [ "$CHECK_INSTALL" -ge "1" ]; then
-        echo "Spack downstreams has detected an existing installation of spack downstreams in your bashrc. (r)eplace|(s)kip"
+    log "export CHECK_INSTALL=$(egrep -c "$NCAR_HOST DOWNSTREAM INITIALIZE" ~/.$MODIFY_RC 2> /dev/null)"
+    export CHECK_INSTALL=$(egrep -c "$NCAR_HOST DOWNSTREAM INITIALIZE" ~/.$MODIFY_RC 2> /dev/null)
+
+    if [ $CHECK_INSTALL -ge 1 ]; then
+        echo -n "Another downstream is already activated by your $MODIFY_RC. Replace (y/N)? "
         while true; do
-	    read UINPUT
-            if [ "$UINPUT" == "r" ]; then
-                log sed -i '/SPACK DOWNSTREAMS INITIALIZE/,/SPACK DOWNSTREAMS DONE/d' ~/.bashrc
-                sed -i '/SPACK DOWNSTREAMS INITIALIZE/,/SPACK DOWNSTREAMS DONE/d' ~/.bashrc
+	        read UINPUT
+            UINPUT=${UINPUT,,}
+            if [[ yes == ${UINPUT:-n}* ]]; then
+                log "sed -i \"/$NCAR_HOST DOWNSTREAM INITIALIZE/,/SPACK DOWNSTREAM DONE/d\" ~/.$MODIFY_RC"
+                sed -i "/$NCAR_HOST DOWNSTREAM INITIALIZE/,/SPACK DOWNSTREAM DONE/d" ~/.$MODIFY_RC
                 break	
-            elif [ "$UINPUT" == "s" ]; then
+            elif [[ no == $UINPUT* ]]; then
                 echo "Skipping... To initialize this installation, please run:"
-		echo ". $INSTALL_DIR/share/spack/setup-env.sh"
-		exit 0
+		        echo "source $INSTALL_DIR/share/spack/setup-env.$SRC_FILE"
+		        exit
             else
-                echo "Please select (r)eplace|(s)kip"
-	    fi
+                echo -n "Please select (y)es or (n)o: "
+	        fi
         done
-    fi 
+    fi
 }
 
 # Modify User RC
-modify_rc () {
-    echo "Modifying bashrc..."
+modify_bashrc () {
+echo -n "Modifying .bashrc... "
 
-    log "echo '# SPACK DOWNSTREAMS INITIALIZE' >> ~/.bashrc"
-    log "echo 'export SPACK_DISABLE_LOCAL_CONFIG=true'"
-    log "echo '[ \$NCAR_HOST == $NCAR_HOST ] && . $INSTALL_DIR/share/spack/setup-env.sh' >> ~/.bashrc"
-    log "echo '# SPACK DOWNSTREAMS DONE' >> ~/.bashrc"
+if [ "$VERBOSE" = "True" ]; then
+cat << EOT
+cat >> ~/.bashrc << EOF
+# --$NCAR_HOST DOWNSTREAM INITIALIZE--
+export SPACK_DISABLE_LOCAL_CONFIG=true
+[ \$NCAR_HOST == $NCAR_HOST ] && . $INSTALL_DIR/share/spack/setup-env.sh
+# --SPACK DOWNSTREAM DONE--
+EOF
+EOT
+fi
 
-    echo "# --SPACK DOWNSTREAMS INITIALIZE--" >> ~/.bashrc
-    echo "export SPACK_DISABLE_LOCAL_CONFIG=true" >> ~/.bashrc
-    echo "[ \$NCAR_HOST == '$NCAR_HOST' ] && . $INSTALL_DIR/share/spack/setup-env.sh" >> ~/.bashrc
-    echo "# --SPACK DOWNSTREAMS DONE--" >> ~/.bashrc
+cat >> ~/.bashrc << EOF
+# --$NCAR_HOST DOWNSTREAM INITIALIZE--
+export SPACK_DISABLE_LOCAL_CONFIG=true
+[ \$NCAR_HOST == $NCAR_HOST ] && . $INSTALL_DIR/share/spack/setup-env.sh
+# --SPACK DOWNSTREAM DONE--
+EOF
 
-    echo '...complete!'
+echo 'complete!'
 }
 
+modify_cshrc () {
+echo -n "Modifying .${MODIFY_RC}... "
+
+if [ "$VERBOSE" = "True" ]; then
+cat << EOT
+cat >> ~/.$MODIFY_RC << EOF
+# --$NCAR_HOST DOWNSTREAM INITIALIZE--
+setenv SPACK_DISABLE_LOCAL_CONFIG true
+if ( \$?NCAR_HOST && \$NCAR_HOST == $NCAR_HOST ) then
+    source $INSTALL_DIR/share/spack/setup-env.csh
+endif
+# --SPACK DOWNSTREAM DONE--
+EOF
+EOT
+fi
+
+cat >> ~/.$MODIFY_RC << EOF
+# --$NCAR_HOST DOWNSTREAM INITIALIZE--
+setenv SPACK_DISABLE_LOCAL_CONFIG true
+if ( \$?NCAR_HOST && \$NCAR_HOST == $NCAR_HOST ) then
+    source $INSTALL_DIR/share/spack/setup-env.csh
+endif
+# --SPACK DOWNSTREAM DONE--
+EOF
+
+echo 'complete!'
+}
+
+# Assume current ncarenv for version by default
+UPSTREAM_VERSION=$NCAR_ENV_VERSION
+
 # Simple flag parser
-while [ "$#" -gt 0 ]
+while [ $# -gt 0 ]
 do
     case "${1}" in
-	(--prefix=?*)     PREFIX="$(echo ${1} | cut -f 2 -d '=')" ;;
-        (-v | --verbose)  VERBOSE="True" ;;
-	(-h | --help)     print_usage; exit 0 ;;
-	(--modify-rc=?*)  MODIFY_RC="$(echo ${1} | cut -f 2 -d '=')" ;;
-        (--version=?*)    VERSION="$(echo ${1} | cut -f 2 -d '=')" ;;
-        (*)               echo "spack-downstream error: unrecognized option ${1}"; print_usage; exit 1 ;;
+	    (--downstream-root=?*)      DOWNSTREAM_ROOT="$(echo ${1} | cut -f 2 -d '=')" ;;
+        (-v | --verbose)            VERBOSE="True" ;;
+	    (-h | --help)               print_usage; exit 0 ;;
+	    (--modify-rc=?*)            MODIFY_RC="$(echo ${1} | cut -f 2 -d '=')" ;;
+        (--upstream-version=?*)     UPSTREAM_VERSION="$(echo ${1} | cut -f 2 -d '=')" ;;
+        (*)                         >&2 echo "Error: unrecognized option ${1}"; print_usage; exit 1 ;;
     esac
     shift
 done
 
 # Temporary Version Identifier
-if [ -z "$VERSION" ]; then
-    if [ ! -z "$NCAR_ENV_VERSION" ]; then
-        VERSION=$NCAR_ENV_VERSION
-    else
-	echo "spack-downstream error: No ncarenv detected. Load a ncarenv before attempting to run spack upstream or set a requested version with --version"
-    fi
+if [ -z "$UPSTREAM_VERSION" ] || [ -z "$NCAR_HOST" ]; then
+    >&2 echo "Error: No ncarenv detected. Load an ncarenv module before attempting to run this script."
+    exit 1
+elif [ ! -d /glade/u/apps/$NCAR_HOST/$UPSTREAM_VERSION ]; then
+    >&2 echo "Error: No software stack found for ncarenv version $UPSTREAM_VERSION."
+    exit 1
 fi
-echo "ncarenv version: $VERSION"
+echo "ncarenv version: $UPSTREAM_VERSION"
 
 # Set install path
-if [ -z "$PREFIX" ]; then
-    INSTALL_DIR="/glade/work/$USER/spack-downstreams/$NCAR_HOST/$VERSION"
-else
-    INSTALL_DIR=$PREFIX
-fi
-echo "prefix: $INSTALL_DIR"
+INSTALL_DIR=${DOWNSTREAM_ROOT:-/glade/work/$USER/spack-downstreams}/$NCAR_HOST/$UPSTREAM_VERSION
+echo -e "prefix: $INSTALL_DIR\n"
 
 # Clone repo
 clone_repo
 
 # Copy YAML files
-copy_yaml 
+copy_yaml
 
-# Modify bashrc
-echo "Spack has been successfully installed and configure for downstream use in: $INSTALL_DIR"
+echo -e "\nSpack has been successfully installed and configured for downstream use!\n"
 
-if [ "$MODIFY_RC" = "True" ]; then
-    check_rc
-    modify_rc
-elif [ "$MODIFY_RC" = "False" ]; then
-    exit 0
+# Modify RC file if desired
+if [[ $SHELL == *csh ]]; then
+    SRC_FILE=sh
+    RCFILE=tcshrc
 else
-    echo "Would you like this installer to automatically initialize spack at login by modifying .bashrc?"
-    echo "(y|n)"
+    SRC_FILE=csh
+    RCFILE=bashrc
+fi
+
+if [[ -z $MODIFY_RC ]]; then
+    echo -n "Would you like to automatically initialize Spack at login by modifying your .bashrc (y/N)? "
+
     while true; do
         read MOD
-        if [ "$MOD" == 'y' ]; then
-            check_rc
-	    modify_rc
-            echo "Modification successful! Please restart your shell to apply changes"
-	    exit 0
-        elif [ "$MOD" == 'n' ]; then
-            echo "To initialize your shell for spack use please run the command:"
-            echo ". $INSTALL_DIR/share/spack/setup-env.sh"
-            exit 0
+        MOD=${MOD,,}
+
+        if [[ yes == ${MOD:-no}* ]]; then
+            MODIFY_RC=yes
+            break
+        elif [[ no == $MOD ]]; then
+            break
         else
-            echo "Please select (y)es|(n)o"
+            echo -n "Please select (y)es or (n)o: "
         fi
     done
 fi
 
+if [[ yes == ${MODIFY_RC:-no}* ]]; then
+    MODIFY_RC=$RCFILE
+elif [[ no == ${MODIFY_RC:-no}* ]]; then
+    echo "To initialize your shell for spack use please run the command:"
+    echo "source $INSTALL_DIR/share/spack/setup-env.$SRC_FILE"
+    exit
+fi
+
+check_rc
+
+if [[ $MODIFY_RC == bashrc ]]; then
+    modify_bashrc
+elif [[ $MODIFY_RC == *cshrc ]]; then
+    modify_cshrc
+else
+    >&2 echo "Error: unrecognized source file $MODIFY_RC. Skipping..."
+    exit 1
+fi
+
+echo "Modification successful! Please restart your shell to apply changes."


### PR DESCRIPTION
Made some changes to fix bugs, improve consistency with other command-line utilities, and add some functionality. Specifically:

1. Any references to Gust were made to be system-agnostic.
2. A bug that could cause incorrect YAML files (from `default` instead of the specified version) is fixed.
3. I changed a couple of environment variable names to make them less generic, so that user environment would be less likely to impact script behavior (i.e. `UPSTREAM_VERSION` instead of `VERSION`).
4. I changed the formatting of the usage/help to better match GNU standard formatting.
5. Added RC support for (t)csh users. If the user doesn't specify which shell to support, it is inferred from the user's `$SHELL` variable.